### PR TITLE
Case 19702 - search for the ckeditor-test-font-size div relative to the edited element

### DIFF
--- a/dist/plugins/setmenu/plugin.js
+++ b/dist/plugins/setmenu/plugin.js
@@ -32,14 +32,16 @@ CKEDITOR.plugins.add( 'setmenu', {
 	        setTimeout(function() {
 
 	        	var baseSize = null;
-				if (editor.config.use_em === true) {
-					$('#ckeditor-test-font-size').remove();
-					$baseline = $('<div id="ckeditor-test-font-size" style="font-size: 1em;"></div>');
-					var $wrapper = $element.parents('.js_ckeditor_wrapper');
-					$wrapper.after($baseline);
-					baseSize = parseInt($('#ckeditor-test-font-size').css('font-size'), 10);
-					$('#ckeditor-test-font-size').remove();
-				}
+
+                if (editor.config.use_em === true) {
+                    var $baseline = $('<div id="ckeditor-test-font-size" style="font-size: 1em;"></div>'),
+                        $wrapper = $element.parents('.js_ckeditor_wrapper');
+
+                    $wrapper.siblings('#ckeditor-test-font-size').remove();
+                    $wrapper.after($baseline);
+                    baseSize = parseInt($wrapper.siblings('#ckeditor-test-font-size').css('font-size'), 10);
+                    $wrapper.siblings('#ckeditor-test-font-size').remove();
+                }
 
 	            var fontMenu = e.editor.ui.get('favfonts') || e.editor.ui.get('Font') //The fontMenu
 	                , fontSizeMenu = e.editor.ui.get('FontSize') //the FontSize Menu


### PR DESCRIPTION
Fixed an issue with the setmenu plugin of the Kartra CKEditor where baseline font-size detection was not working properly for em units. (19702)