### PR TITLE
Hotfix for mergestyles plugin jQuery CVE patch error

### DIFF
--- a/dist/plugins/mergestyles/plugin.js
+++ b/dist/plugins/mergestyles/plugin.js
@@ -38,6 +38,8 @@ CKEDITOR.plugins.add('mergestyles', {
                             } else {
                                 oldContent = editor.element.getHtml();
                             }
+
+                            oldContent = oldContent.trimStart();
                         }
 
                         editor.fire('saveSnapshot');
@@ -77,6 +79,8 @@ CKEDITOR.plugins.add('mergestyles', {
             } else {
                 newContent = editor.element.getHtml();
             }
+
+            newContent = newContent.trimStart();
 
             if (
                 currentContent !== newContent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kartra-ckeditor",
-  "version": "1.0.78",
+  "version": "1.0.79",
   "description": "Kartra ckeditor",
   "browser": "dist/ckeditor.js",
   "repository": {


### PR DESCRIPTION
Fixed an issue in the mergestyles CKEditor plugin where there were errors thrown because of the jQuery CVE patch.